### PR TITLE
make mlock work as non-priviliged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM cloudron/base:2.0.0@sha256:f9fea80513aa7c92fe2e7bf3978b54c8ac5222f47a9a32a7f8833edf0eb5a4f4
 
+RUN apt-get update && \
+    apt-get install -y libcap2-bin && \
+    rm -rf /var/cache/apt /var/lib/apt/lists
+
 # this is the default port for the webui and the REST gui
 EXPOSE 8200 8201
 
@@ -29,13 +33,15 @@ COPY start.sh /app/pkg
 COPY configure_ldap.sh /app/data
 
 # organise some permissions and make some stuff executable
-RUN chown -R cloudron:cloudron /app/code /app/pkg
 RUN chmod +x /app/pkg/start.sh
 RUN chmod +x /app/data/configure_ldap.sh
 
 # sorting out the supervisor configs and their log files
 RUN sed -e 's,^logfile=.*$,logfile=/run/supervisord.log,' -i /etc/supervisor/supervisord.conf
 COPY supervisor-vault.conf /etc/supervisor/conf.d/
+
+# set file caps so the executable can run mlock as non privileged user (https://github.com/hashicorp/vault/issues/122)
+RUN setcap cap_ipc_lock=+ep /app/code/vault
 
 # set the container to connect into the data folder as a nice user friendly thing
 WORKDIR /app/data


### PR DESCRIPTION
This PR makes mlock work as the `cloudron` user instead of root.